### PR TITLE
Big code cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -243,9 +243,14 @@ class SaveHandler(_BaseHandler):
     capdefault.put()
     pcapdata.put()
 
-    self.redirect('/d3viz.html#key=%s&to_plot=%s'
+    ack = 'false'
+    if self.request.get('include-acks') == 'on':
+      ack = 'true'
+
+    self.redirect('/d3viz.html#key=%s&to_plot=%s&ack=%s'
                   % (_Esc(str(blob_info.key())),
-                  _Esc(','.join(pcapdata.show_fields))))
+                  _Esc(','.join(pcapdata.show_fields)),
+                  _Esc(ack)))
 
 class _CacheMissing(Exception):
   pass

--- a/view.html
+++ b/view.html
@@ -39,7 +39,7 @@
   </table>
   <div style='padding: 1em'>
   <input type='checkbox' name='include-acks' id='include-acks'>
-  <label for='include-acks'>Include Acks?</label>
+  <label for='include-acks'>Include 1D ACKs?</label>
   </input>
   </div>
   <input type='checkbox' name='update-cache' id='update-cache'>

--- a/wavedroplet.css
+++ b/wavedroplet.css
@@ -49,8 +49,10 @@
 
     .text-label {
       font-family: sans-serif;
-      font-size: 18px;
+      font-size: 14px;
+      fill: grey;
     }
+
 
     .focus {
       opacity: 1;

--- a/wavedroplet.css
+++ b/wavedroplet.css
@@ -37,8 +37,8 @@
     .axis path,
     .axis line {
       fill: none;
-      stroke: black;
-      stroke-width: 1px;
+      stroke: grey;
+      stroke-width: .8px;
       shape-rendering: crispEdges;  
     }
 

--- a/wavedroplet.css
+++ b/wavedroplet.css
@@ -141,3 +141,8 @@
       opacity: 1;
       fill: #890000;
     }
+
+    .drag_rect {
+      fill: black;
+      opacity: .1;
+    }

--- a/wavedroplet.js
+++ b/wavedroplet.js
@@ -184,9 +184,9 @@ var boolean_area = false // show boolean area charts
 
 // x (pcap) axis for all charts
 var pcapSecsAxis = d3.svg.axis()
-    .tickFormat(hourMinuteMilliseconds)
+    .tickFormat(milliseconds)
     .orient('bottom')
-    .ticks(5);
+    .ticks(3);
 
 // brush object for zooming using top level histogram chart
 var brush = d3.svg.brush()
@@ -1452,5 +1452,5 @@ function hourMinuteMilliseconds(d) {
 }
 
 function milliseconds(d) {
-    return d3.time.format("%L")(new Date(d * 1000))
+    return d3.time.format("%Ss %Lms")(new Date(d * 1000))
 }

--- a/wavedroplet.js
+++ b/wavedroplet.js
@@ -709,21 +709,6 @@ function visualize_retrybad(svg) {
     draw_rect_for_zooming(svg, dimensions.height.per_chart * field_settings['retry-bad'].height_factor)
 }
 
-
-// function to transform stack data into area charts
-var retrybad_percent_area = d3.svg.area()
-    .x(function(d) {
-        return state.scales['pcap_secs'](d.x);;
-    })
-    .y0(function(d) {
-        return dimensions.height.per_chart * (1 - dimensions.height.split_factor) * d.y0 +
-            dimensions.height.per_chart * dimensions.height.split_factor;
-    })
-    .y1(function(d) {
-        return dimensions.height.per_chart * (1 - dimensions.height.split_factor) * (d.y + d.y0) +
-            dimensions.height.per_chart * dimensions.height.split_factor;
-    });
-
 function enter_boolean_boxes_by_dataset(fieldName, svg) {
 
     svg.enter()
@@ -942,8 +927,10 @@ function update_pcaps_domain(newDomain, transition_bool) {
         }
 
         if (field_settings[fieldName].value_type == 'boolean') {
+            /* percent area
             d3.selectAll(".percent_area_chart_boolean_" + fieldName)
                 .attr("d", boolean_percent_of_total_area_setup(trimmed_data, fieldName, scaled('pcap_secs')));
+                */
 
             var bool_boxes_current = d3.select(".boolean_boxes_" + fieldName)
                 .selectAll(".bool_boxes_rect_" + fieldName)
@@ -989,10 +976,12 @@ function update_pcaps_domain(newDomain, transition_bool) {
             enter_retrybad_boxes_by_dataset(bool_boxes_current)
 
             // PERCENT CHART
+            /* percent area
             d3.selectAll(".percent_area")
                 .attr("d", function(d) {
                     return retrybad_percent_area(d);
                 })
+*/
         }
 
 
@@ -1355,9 +1344,7 @@ function draw_boolean_percent_chart(field, svg) {
         .attr("class", "percent_area_chart_boolean_" + field)
         .attr("d", boolean_percent_of_total_area_setup(dataset, field, scaled('pcap_secs')));
 }
-*/
 
-/*
 function boolean_percent_of_total_area_setup(data, currentField, xFunc) {
 
     // percent 1 vs 0
@@ -1382,9 +1369,7 @@ function boolean_percent_of_total_area_setup(data, currentField, xFunc) {
 
     return k(data)
 }
-*/
 
-/*
 function draw_retrybad_percent_chart(svg) {
     // set up data for rolling average
     var runningSeq = {
@@ -1458,4 +1443,19 @@ function draw_retrybad_percent_chart(svg) {
         });
 
 }
+
+// function to transform stack data into area charts
+var retrybad_percent_area = d3.svg.area()
+    .x(function(d) {
+        return state.scales['pcap_secs'](d.x);;
+    })
+    .y0(function(d) {
+        return dimensions.height.per_chart * (1 - dimensions.height.split_factor) * d.y0 +
+            dimensions.height.per_chart * dimensions.height.split_factor;
+    })
+    .y1(function(d) {
+        return dimensions.height.per_chart * (1 - dimensions.height.split_factor) * (d.y + d.y0) +
+            dimensions.height.per_chart * dimensions.height.split_factor;
+    });
+
 */

--- a/wavedroplet.js
+++ b/wavedroplet.js
@@ -186,7 +186,7 @@ var boolean_area = false // show boolean area charts
 var pcapSecsAxis = d3.svg.axis()
     .tickFormat(milliseconds)
     .orient('bottom')
-    .ticks(3);
+    .ticks(5);
 
 // brush object for zooming using top level histogram chart
 var brush = d3.svg.brush()
@@ -444,7 +444,7 @@ function add_overview() {
         .scale(state.scales['pcap_secs_fixed'])
         .tickFormat(hourMinuteMilliseconds)
         .orient('bottom')
-        .ticks(5);
+    .ticks(5);
 
     // start building the chart
     var overviewChart = d3

--- a/wavedroplet.js
+++ b/wavedroplet.js
@@ -21,7 +21,7 @@ var total_height = w.innerHeight || e.clientHeight || g.clientHeight;
 // set chart dimensions
 var dimensions = {
     page: {
-        left: 30,
+        left: 50,
         top: 30
     },
     height: {
@@ -437,8 +437,8 @@ function add_overview() {
     // set up x and y axis
     var overviewYaxis = d3.svg.axis()
         .scale(state.scales['packetNumPerTenth'])
-        .orient('right')
-        .ticks(3);
+        .orient('left')
+        .ticks(5);
 
     var overviewXaxis = d3.svg.axis()
         .scale(state.scales['pcap_secs_fixed'])
@@ -465,7 +465,6 @@ function add_overview() {
 
     overviewChart.append('g')
         .attr('class', 'axis y overview')
-        .attr('transform', 'translate(' + dimensions.width.chart + ', 0)')
         .call(overviewYaxis);
 
     // draw bars
@@ -815,9 +814,7 @@ function determine_selected_class(d) {
             return "";
         }
     }
-
 }
-
 
 function visualize_numbers(field, svg) {
     setup_crosshairs(field, svg)
@@ -841,15 +838,14 @@ function draw_rect_for_zooming(svg, height) {
     svg.append("rect")
         .attr("height", height)
         .attr("width", 0)
-        .attr("fill", "grey")
-        .attr("opacity", .1)
         .attr("x", 0)
         .attr("y", 0)
         .attr("class", "drag_rect hidden")
 }
 
 function draw_points(fieldName, svg) {
-    svg.append('g').attr("class", 'pcap_vs_' + fieldName + " metricChart").attr("fill", 'grey')
+    svg.append('g').attr("class", 'pcap_vs_' + fieldName + " metricChart")
+        .attr("fill", 'grey')
         .selectAll('.points')
         .data(dataset, function(d) {
             return d.pcap_secs
@@ -867,20 +863,20 @@ function draw_points(fieldName, svg) {
 function draw_metric_y_axis(svg, fieldName) {
     var yAxis = d3.svg.axis()
         .scale(state.scales[fieldName])
-        .orient('right')
+        .orient('left')
         .ticks(5);
 
     // y axis
     svg.append('g')
         .attr('class', 'axis y')
-        .attr('transform', 'translate(' + (dimensions.width.chart) + ',0)')
+        //  .attr('transform', 'translate(' + (dimensions.width.chart) + ',0)')
         .call(yAxis);
 }
 
 function draw_metric_x_axis(svg, fieldName) {
     // title for plot
     svg.append("text")
-        .attr('transform', 'translate(-10,' + field_settings[fieldName].translate_label + ') rotate(-90)')
+        .attr('transform', 'translate(-25,' + field_settings[fieldName].translate_label + ') rotate(-90)')
         .attr("class", "text-label")
         .text(fieldName);
 


### PR DESCRIPTION
- stopped passing start_time and js_streams from python to js, added note in python that these need to be removed (they're still being setup, just not passed)
- remove sanitize step
      - handle null ta's
- added checkbox to include/exclude 1D ACK
- moved chart titles and y-axis to left side
- using seconds and milliseconds for time on detail charts
- comment out boolean area charts that are unused
- added new data structure, dict_by_ms, to speed up mouseovers w/ crosshairs
- lots of cleanup, adding comments, tightening code, etc
